### PR TITLE
DOPS-582 Added ability to use regional values files

### DIFF
--- a/bogie/process.go
+++ b/bogie/process.go
@@ -98,6 +98,7 @@ func fileExists(filename string) bool {
 	}
 	return !info.IsDir()
 }
+
 func setValueContext(app *ApplicationInput, old *context) (*context, error) {
 	c := context{}
 

--- a/bogie/process.go
+++ b/bogie/process.go
@@ -8,9 +8,9 @@ import (
 	"sort"
 	"strings"
 
+	bogieio "github.com/BeenVerifiedInc/bogie/io"
 	dotaccess "github.com/go-bongo/go-dotaccess"
 	"github.com/imdario/mergo"
-	bogieio "github.com/BeenVerifiedInc/bogie/io"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -102,14 +102,15 @@ func setValueContext(app *ApplicationInput, old *context) (*context, error) {
 	c := context{}
 
 	files := []string{}
-	if val, ok := old.Values["default_region"]; ok {
-		regionalFileName := fmt.Sprintf("%s/%s.%s.values.yaml", app.Templates, app.Env, val)
-		if fileExists(regionalFileName) {
-			files = append(files, regionalFileName)
-		}
-	}
 
 	if app.Env != "" {
+		if defaultRegion, ok := old.Values["default_region"]; ok {
+			regionalFileName := fmt.Sprintf("%s/%s.%s.values.yaml", app.Templates, app.Env, defaultRegion)
+			if fileExists(regionalFileName) {
+				files = append(files, regionalFileName)
+			}
+		}
+
 		files = append(files, fmt.Sprintf("%s/%s.values.yaml", app.Templates, app.Env))
 	}
 

--- a/bogie/process.go
+++ b/bogie/process.go
@@ -2,6 +2,7 @@ package bogie
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -90,10 +91,23 @@ func genContext(envfile string) (*context, error) {
 	return &c, nil
 }
 
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
 func setValueContext(app *ApplicationInput, old *context) (*context, error) {
 	c := context{}
 
 	files := []string{}
+	if val, ok := old.Values["default_region"]; ok {
+		regionalFileName := fmt.Sprintf("%s/%s.%s.values.yaml", app.Templates, app.Env, val)
+		if fileExists(regionalFileName) {
+			files = append(files, regionalFileName)
+		}
+	}
 
 	if app.Env != "" {
 		files = append(files, fmt.Sprintf("%s/%s.values.yaml", app.Templates, app.Env))


### PR DESCRIPTION
This is currently coded to look for "default_region" in the environment file.  The one specified with -e such as carl.production.values.   The value here is what will be looked for in the file names such as production.us-east-1.values.yaml